### PR TITLE
netbox_ipam_prefixes: support for `family` and `vrf_id` properties

### DIFF
--- a/docs/data-sources/netbox_ipam_prefixes.md
+++ b/docs/data-sources/netbox_ipam_prefixes.md
@@ -33,6 +33,10 @@ data "netbox_ipam_prefixes" "example" {
 
 * `tenant` - (Optional) - The name of a tenant.
 
+* `family` - (Optional) - A value for the address family. Possible values include: `4` and `6`.
+
+* `vrf_id` - (Optional) - The ID of the VRF.
+
 * `within` - (Optional) - A case insensitive `within` value, used to filter the results.
 
 * `within_include` - (Optional) A case insensitive `within_include` value, used to filter the results.

--- a/netbox/data_source_ipam_prefixes.go
+++ b/netbox/data_source_ipam_prefixes.go
@@ -63,6 +63,16 @@ func dataSourceIpamPrefixes() *schema.Resource {
 				Optional: true,
 			},
 
+			"family": {
+				Type:     schema.TypeFloat,
+				Optional: true,
+			},
+
+			"vrf_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
 			"within": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -337,6 +347,16 @@ func dataSourceIpamPrefixesRead(ctx context.Context, d *schema.ResourceData, m i
 	if v, ok := d.GetOk("tenant"); ok {
 		tenant := v.(string)
 		params.Tenant = &tenant
+	}
+
+	if v, ok := d.GetOk("family"); ok {
+		family := v.(float64)
+		params.Family = &family
+	}
+
+	if v, ok := d.GetOk("vrf_id"); ok {
+		vrfID := v.(string)
+		params.VrfID = &vrfID
 	}
 
 	if v, ok := d.GetOk("within"); ok {

--- a/netbox/data_source_ipam_prefixes_test.go
+++ b/netbox/data_source_ipam_prefixes_test.go
@@ -2,13 +2,14 @@ package netbox
 
 import (
 	"fmt"
+	"math/rand"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 func TestAccDataSourceIpamPrefixes_basic(t *testing.T) {
-	prefix := "10.0.0.0/16"
+	prefix := fmt.Sprintf("10.%d.0.0/16", rand.Intn(255))
 
 	resource.Test(t, resource.TestCase{
 		Providers: testAccProviders,
@@ -17,6 +18,22 @@ func TestAccDataSourceIpamPrefixes_basic(t *testing.T) {
 				Config: testAccDataSourceIpamPrefixesConfig(prefix),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.netbox_ipam_prefixes.test", "results.0.prefix", prefix),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceIpamPrefixes_Family(t *testing.T) {
+	prefix := fmt.Sprintf("10.%d.0.0/16", rand.Intn(255))
+
+	resource.Test(t, resource.TestCase{
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceIpamPrefixesFamilyConfig(prefix),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.netbox_ipam_prefixes.test", "results.0.family.0.value", "4"),
 				),
 			},
 		},
@@ -32,6 +49,22 @@ resource "netbox_ipam_prefix" "test" {
 
 data "netbox_ipam_prefixes" "test" {
   prefix = netbox_ipam_prefix.test.prefix
+  depends_on = [
+    netbox_ipam_prefix.test,
+  ]
+}
+`, prefix)
+}
+
+func testAccDataSourceIpamPrefixesFamilyConfig(prefix string) string {
+	return fmt.Sprintf(`
+resource "netbox_ipam_prefix" "test" {
+  prefix = "%s"
+  status = "active"
+}
+
+data "netbox_ipam_prefixes" "test" {
+  family = 4
   depends_on = [
     netbox_ipam_prefix.test,
   ]


### PR DESCRIPTION
Fixes #27